### PR TITLE
Fixed QS status bar paddings.

### DIFF
--- a/overlay/OPlusSystemUIResTarget/res/values/dimens.xml
+++ b/overlay/OPlusSystemUIResTarget/res/values/dimens.xml
@@ -33,4 +33,8 @@
      <!-- QQS Bottom Padding. -->
      <dimen name="qqs_layout_padding_bottom">24.0dip</dimen>
 
+     <!-- QS Panel status bar padding fix. -->
+    <dimen name="large_screen_shade_header_left_padding">28dp</dimen>
+    <dimen name="hover_system_icons_container_padding_end">10dp</dimen>
+
 </resources>


### PR DESCRIPTION
![photo_2025-02-02_06-04-30](https://github.com/user-attachments/assets/1f423f74-4d07-4257-8272-3e3af07945ee)
Changed only the paddings that are shown with the arrows.